### PR TITLE
fix: usuń duplikat dokumentu HTML i napraw polskie znaki

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
     "name": "Elektro - Impuls",
     "url": "https://elektro-impuls.azurestaticapps.net/",
     "image": "https://elektro-impuls.azurestaticapps.net/assets/logo01.png",
-    "telephone": "+48 600 000 000",
+    "telephone": "+48 603 138 233",
     "address": {
       "@type": "PostalAddress",
       "addressLocality": "Gdańsk",
@@ -159,7 +159,7 @@
         <span class="muted">Gdańsk, Polska</span>
       </div>
       <div class="footer-col">
-        <a class="btn" href="tel:+48600000000" aria-label="Zadzwoń do nas">Zadzwoń: +48&nbsp;600&nbsp;000&nbsp;000</a>
+        <a class="btn" href="tel:+48603138233" aria-label="Zadzwoń do nas">Zadzwoń: +48&nbsp;603&nbsp;138&nbsp;233</a>
       </div>
       <div class="footer-col muted">
         <a href="#">Polityka prywatności</a>
@@ -171,176 +171,4 @@
 </body>
 
 </html>
-<!doctype html>
-<html lang="pl">
 
-<head>
-  <!--
-  ======= Instrukcje szybkiego startu =======
-  1) Podmień KONFIGURACJĘ w script.js (NAZWA, OPIS, AVATAR_URL, FACEBOOK_URL)
-  2) Zastąp obrazki w galerii (assets/*) — możesz też linkować do zewnętrznych URL-i.
-  3) Podepnij własną domenę — zaktualizuj meta tagi (og:url, canonical) poniżej.
-  ===========================================
-  -->
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Elektro - Impuls</title>
-  <meta name="description" content="Oficjalna strona firmy Elektro - Impuls — informacje i kontakt." />
-  <link rel="canonical" href="https://elektro-impuls.azurestaticapps.net/" />
-  <meta name="theme-color" content="#0b1220" />
-
-  <!-- Open Graph / Social -->
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Elektro - Impuls" />
-  <meta property="og:description" content="Informacje o firmie Elektro - Impuls i kontakt." />
-  <meta property="og:url" content="https://elektro-impuls.azurestaticapps.net/" />
-  <meta property="og:image" content="https://elektro-impuls.azurestaticapps.net/assets/logo01.png" />
-  <meta property="og:locale" content="pl_PL" />
-  <!-- Twitter -->
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Elektro - Impuls" />
-  <meta name="twitter:description" content="Instalacje elektryczne i usuwanie awarii — kontakt i informacje." />
-  <meta name="twitter:image" content="https://elektro-impuls.azurestaticapps.net/assets/logo01.png" />
-
-  <!-- Favicon (podmień na finalny plik ikony) -->
-  <link rel="icon" href="assets/logo01.png" />
-
-  <link rel="stylesheet" href="styles.css">
-  <meta name="color-scheme" content="dark light">
-</head>
-
-<body>
-
-  <header>
-    <div class="container nav">
-      <div class="brand">
-        <img id="brandAvatar" src="assets/logo01.png" alt="Avatar" width="40" height="40" />
-        <span id="brandName">Elektro - Impuls</span>
-      </div>
-      <nav class="menu" aria-label="Główne">
-        <a href="#o-mnie">O&nbsp;mnie</a>
-        <a href="#galeria">Galeria</a>
-        <a class="btn btn--brand" id="fbBtn" href="#" target="_blank" rel="noopener noreferrer">Facebook</a>
-      </nav>
-    </div>
-  </header>
-
-  <main id="main">
-    <!-- HERO -->
-    <section class="hero">
-      <div class="container hero-wrap">
-        <div class="hero-copy">
-          <h1 id="heroTitle">Witaj na oficjalnej stronie firmy Elektro - Impuls</h1>
-          <p id="heroSubtitle">Tu znajdziesz najnowsze informacje i kontakt do firmy.</p>
-          <div class="cta">
-            <a class="btn btn--brand" id="ctaFacebook" href="#" target="_blank" rel="noopener noreferrer" aria-label="Otwórz na Facebooku">Zobacz na Facebooku</a>
-          </div>
-        </div>
-        <div class="hero-visual">
-          <picture>
-            <source srcset="assets/logo01.webp" type="image/webp" />
-            <img id="heroAvatar" class="avatar" src="assets/logo01.png" alt="Zdjęcie profilowe" width="160" height="160" loading="lazy" decoding="async" />
-          </picture>
-        </div>
-      </div>
-    </section>
-
-    <!-- O MNIE / O NAS -->
-    <section id="o-mnie" class="reveal">
-      <div class="container">
-        <h2 class="section-title">O&nbsp;mnie</h2>
-        <p class="muted">Elektro - Impuls to firma zajmująca się instalacjami elektrycznymi i usuwaniem awarii elektrycznych.
-          Tu znajdziesz najnowsze informacje i kontakt do firmy.</p>
-        <div class="cards" style="margin-top: 16px;">
-          <div class="card"><strong>Specjalizacja</strong><br><span class="muted">Instalacje elektryczne, naprawy,
-              serwis</span></div>
-          <div class="card"><strong>Miasto</strong><br><span class="muted">Gdańsk, Polska</span></div>
-          <div class="card"><strong>Kontakt</strong><br><span class="muted"><a
-                href="mailto:zbigniew.kalinowski80@gmail.com">zbigniew.kalinowski80@gmail.com</a></span></div>
-        </div>
-      </div>
-    </section>
-
-    <!-- USŁUGI -->
-    <section id="uslugi" class="reveal">
-      <div class="container">
-        <h2 class="section-title">Usługi</h2>
-        <div class="cards" style="margin-top: 16px;">
-          <div class="card"><strong>Montaż i modernizacja</strong><br><span class="muted">Instalacje elektryczne w domach i lokalach</span></div>
-          <div class="card"><strong>Usuwanie awarii</strong><br><span class="muted">Szybka diagnostyka i naprawy na miejscu</span></div>
-          <div class="card"><strong>Pomiary</strong><br><span class="muted">Przeglądy, pomiary, protokoły</span></div>
-          <div class="card"><strong>Doradztwo</strong><br><span class="muted">Dobór rozwiązań i materiałów</span></div>
-        </div>
-        <div class="cta" style="margin-top:16px;">
-          <a class="btn btn--brand" href="tel:+48600000000" aria-label="Zadzwoń teraz">Zadzwoń teraz</a>
-        </div>
-      </div>
-    </section>
-
-    <!-- GALERIA -->
-    <section id="galeria" class="reveal">
-      <div class="container">
-        <h2 class="section-title">Galeria</h2>
-        <div class="gallery">
-          <picture>
-            <source srcset="assets/logo01.webp" type="image/webp" />
-            <img src="assets/logo01.png" width="800" height="600" alt="Zdjęcie 1" loading="lazy" decoding="async" />
-          </picture>
-          <picture>
-            <source srcset="assets/logo01.webp" type="image/webp" />
-            <img src="assets/logo01.png" width="800" height="600" alt="Zdjęcie 2" loading="lazy" decoding="async" />
-          </picture>
-          <picture>
-            <source srcset="assets/logo01.webp" type="image/webp" />
-            <img src="assets/logo01.png" width="800" height="600" alt="Zdjęcie 3" loading="lazy" decoding="async" />
-          </picture>
-          <picture>
-            <source srcset="assets/logo01.webp" type="image/webp" />
-            <img src="assets/logo01.png" width="800" height="600" alt="Zdjęcie 4" loading="lazy" decoding="async" />
-          </picture>
-        </div>
-      </div>
-    </section>
-  </main>
-
-  <!-- Dane strukturalne (schema.org) -->
-  <script id="schemaData" type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "Electrician",
-    "name": "Elektro - Impuls",
-    "url": "https://elektro-impuls.azurestaticapps.net/",
-    "image": "https://elektro-impuls.azurestaticapps.net/assets/logo01.png",
-    "telephone": "+48 600 000 000",
-    "address": {
-      "@type": "PostalAddress",
-      "addressLocality": "Gdańsk",
-      "addressCountry": "PL"
-    },
-    "areaServed": ["Gdańsk", "Pomorskie"],
-    "openingHours": ["Mo-Fr 08:00-18:00", "Sa 09:00-14:00"],
-    "sameAs": [
-      "https://www.facebook.com/profile.php?id=61579354546553"
-    ]
-  }
-  </script>
-
-  <footer class="site-footer">
-    <div class="container footer-wrap">
-      <div class="footer-col">
-        <strong>Elektro - Impuls</strong><br/>
-        <span class="muted">Gdańsk, Polska</span>
-      </div>
-      <div class="footer-col">
-        <a class="btn" href="tel:+48600000000" aria-label="Zadzwoń do nas">Zadzwoń: +48&nbsp;600&nbsp;000&nbsp;000</a>
-      </div>
-      <div class="footer-col muted">
-        <a href="#">Polityka prywatności</a>
-      </div>
-    </div>
-  </footer>
-
-  <script src="script.js"></script>
-</body>
-
-</html>


### PR DESCRIPTION
- Usuń drugą, zdublowaną kopię <!doctype html>… po </html>\n- Popraw polskie znaki (UTF-8) w treści, meta, aria-label i alt\n- Uporządkuj opisy i etykiety (Gdańsk, Usługi, Montaż, itp.)